### PR TITLE
:bug: ZipInfo ValueError workaround

### DIFF
--- a/gordon/resources/lambdas.py
+++ b/gordon/resources/lambdas.py
@@ -489,7 +489,14 @@ class Lambda(base.BaseResource):
                         if six.PY2:
                             source = source.decode('utf-8', errors='strict')
                             relative_destination = relative_destination.decode('utf-8', errors='strict')
-                        zf.write(source, relative_destination)
+                        try:
+                            zf.write(source, relative_destination)
+                        except ValueError as exc:
+                            if exc.message == 'ZIP does not support timestamps before 1980':
+                                os.utime(source, None)
+                                zf.write(source, relative_destination)
+                            else:
+                                raise exc
 
             tmp.seek(0)
             output = six.BytesIO(tmp.read())


### PR DESCRIPTION
ValueError('ZIP does not support timestamps before 1980') workaround

Some files in some `npm` packages have corrupted modified times with dates before 1980, which triggers [ZipInfo ValueError](https://github.com/enthought/Python-2.7.3/blob/master/Lib/zipfile.py#L295)

Workaround:
Catch the error, then update the modified times of the file with [`os.utime`](https://docs.python.org/2/library/os.html#os.utime) to the current time(with `None`), then write the file to the Zip archive, otherwise re-raise the exception.